### PR TITLE
leading back button on login page removed

### DIFF
--- a/lib/login.dart
+++ b/lib/login.dart
@@ -48,6 +48,7 @@ class _LoginState extends State<Login> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         backgroundColor: Colors.black87,
         title: Text('Login'),
         centerTitle: true,


### PR DESCRIPTION
Problem:
The login page should not contain any back button.

Solution:
I set the appBar property of "automaticallyImplyLeading" as false. 

Result:
The back button on the app bar is removed